### PR TITLE
Updated examples for the Logging Framework

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -16,6 +16,8 @@ namespace T3docs\Examples\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Backend\Clipboard\Clipboard;
 use TYPO3\CMS\Backend\Template\Components\Menu\Menu;
 use TYPO3\CMS\Backend\Template\Components\Menu\MenuItem;
@@ -43,9 +45,9 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * @package TYPO3
  * @subpackage tx_examples
  */
-class ModuleController extends ActionController
+class ModuleController extends ActionController implements LoggerAwareInterface
 {
-
+    use LoggerAwareTrait;
     /**
      * @var BackendTemplateView
      */
@@ -158,24 +160,23 @@ class ModuleController extends ActionController
     }
 
     /**
-     * Creates some entries using the 6.0+ logging API
+     * Creates some entries using the logging API
+     * $this->logger gets set by usage of the LoggerAwareTrait
      *
      * @return void
      */
     public function logAction()
     {
-        /** @var $logger \TYPO3\CMS\Core\Log\Logger */
-        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-        $logger->info('Everything went fine.');
-        $logger->warning('Something went awry, check your configuration!');
-        $logger->error(
+        $this->logger->info('Everything went fine.');
+        $this->logger->warning('Something went awry, check your configuration!');
+        $this->logger->error(
             'This was not a good idea',
             [
                 'foo' => 'bar',
                 'bar' => $this,
             ]
         );
-        $logger->log(
+        $this->logger->log(
             LogLevel::CRITICAL,
             'This is an utter failure!'
         );

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,7 @@ Sample Extension "examples"
 is currently outdated. The most recent version of this extension is 0.8.0 for TYPO3 8.
 
 **Instalation:** Can be installed via composer:
-.. code:: bash
-
-    composer req t3docs/examples
+``composer req t3docs/examples``
 
 This extension provides a number of code examples used in the TYPO3 Core Documentation.
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Sample Extension "examples"
 **Important:** The extension in the Extension Repository and the rendered documentation
 is currently outdated. The most recent version of this extension is 0.8.0 for TYPO3 8.
 
-**Instalation:** Can be installed via composer:
+**Installation:** Can be installed via composer:
 ``composer req t3docs/examples``
 
 This extension provides a number of code examples used in the TYPO3 Core Documentation.
@@ -20,6 +20,6 @@ Refer to the documentation for more details.
 :Code Repository:  https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples
 :Read Documentation Online: https://docs.typo3.org/typo3cms/extensions/examples/
 :TYPO3 Extension Repository: https://extensions.typo3.org/extension/examples/
-:Extension Key:  examplesRE
+:Extension Key:  examples
 
 .. mirror also contains outdated version: https://github.com/TYPO3-extensions/examples

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,11 @@ Sample Extension "examples"
 **Important:** The extension in the Extension Repository and the rendered documentation
 is currently outdated. The most recent version of this extension is 0.8.0 for TYPO3 8.
 
+**Instalation:** Can be installed via composer:
+.. code:: bash
+
+    composer req t3docs/examples
+
 This extension provides a number of code examples used in the TYPO3 Core Documentation.
 
 Refer to the documentation for more details.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -24,8 +24,26 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions'] = [
     ],
 ];
 
-$GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::DEBUG] = $GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::DEBUG];
+
 // Add example configuration for the logging API
+
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'] = [
+    // configuration for ERROR level log entries
+    \TYPO3\CMS\Core\Log\LogLevel::ERROR => [
+        // add a FileWriter
+        \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
+            // configuration for the writer
+            'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/typo3_examples.log'
+        ]
+    ]
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::DEBUG] = [
+    \TYPO3\CMS\Core\Log\Writer\DatabaseWriter::class => [
+        'logTable' => 'tx_examples_log'
+    ],
+];
+
 $GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::WARNING] = [
     // configuration for WARNING severity, including all
     // levels with higher severity (ERROR, CRITICAL, EMERGENCY)
@@ -41,6 +59,7 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['processo
         ],
     ],
 ];
+
 
 // Register the "error " plugin
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -33,14 +33,14 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerCo
         // add a FileWriter
         \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
             // configuration for the writer
-            'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/typo3_examples.log'
+            'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/typo3_examples.log',
         ]
     ]
 ];
 
 $GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::DEBUG] = [
     \TYPO3\CMS\Core\Log\Writer\DatabaseWriter::class => [
-        'logTable' => 'tx_examples_log'
+        'logTable' => 'tx_examples_log',
     ],
 ];
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -81,3 +81,18 @@ CREATE TABLE tx_examples_haiku (
 
 	PRIMARY KEY (uid)
 );
+
+# Table structure for table 'tx_examples_log'
+#
+# The KEY on request_id is optional
+#
+CREATE TABLE tx_examples_log (
+	request_id varchar(13) DEFAULT '' NOT NULL,
+	time_micro double(16,4) NOT NULL default '0.0000',
+	component varchar(255) DEFAULT '' NOT NULL,
+	level tinyint(1) unsigned DEFAULT '0' NOT NULL,
+	message text,
+	data text,
+
+	KEY request (request_id)
+);


### PR DESCRIPTION
Updated examples for the Logging Framework to use LoggerAwareInterface instead of GeneralUtility::makeInstance.

Added a working example to write the log to a custom database table.